### PR TITLE
AddSignatory mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/bin
 **/obj
 node_modules
+test-local.sh

--- a/Criipto.Signatures.IntegrationTests/AddSignatoryTests.cs
+++ b/Criipto.Signatures.IntegrationTests/AddSignatoryTests.cs
@@ -1,0 +1,53 @@
+using Xunit;
+using Criipto.Signatures;
+using System.Collections.Generic;
+using System.IO;
+namespace Criipto.Signatures.IntegrationTests;
+
+public class AddSignatoryTests
+{
+    public static string CLIENT_ID = System.Environment.GetEnvironmentVariable("CRIIPTO_SIGNATURES_CLIENT_ID")!;
+    public static string CLIENT_SECRET = System.Environment.GetEnvironmentVariable("CRIIPTO_SIGNATURES_CLIENT_SECRET")!;
+    public static byte[] Sample = File.ReadAllBytes("./sample.pdf");
+
+    [Fact]
+    public void ClientCredentialsSet()
+    {
+        Assert.NotNull(CLIENT_ID);
+        Assert.NotNull(CLIENT_SECRET);
+    }
+
+    [Fact]
+    public async void MutationReturnsSignatory()
+    {
+        using (var client = new CriiptoSignaturesClient(CLIENT_ID, CLIENT_SECRET))
+        {
+            // Arrange
+            var signatureOrder = await client.CreateSignatureOrder(
+                new Types.CreateSignatureOrderInput()
+                {
+                    title = "Title",
+                    expiresInDays = 1,
+                    documents = new List<Types.DocumentInput>(){
+                        new Types.DocumentInput {
+                            pdf =
+                                new Types.PadesDocumentInput
+                                {
+                                    title = "TEST",
+                                    blob = Sample
+                                }
+                        }
+                    }
+                }
+            );
+
+            // Act
+            var signatory = await client.AddSignatory(
+                signatureOrder
+            );
+
+            // Assert
+            Assert.NotNull(signatory?.id);
+        }
+    }
+}

--- a/Criipto.Signatures/Client.cs
+++ b/Criipto.Signatures/Client.cs
@@ -51,6 +51,8 @@ public class CriiptoSignaturesClient : IDisposable
 
     public async Task<Types.SignatureOrder> CreateSignatureOrder(Types.CreateSignatureOrderInput input)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+
         var response = await graphQLClient.SendMutationAsync(
             CreateSignatureOrderMutation.Request(new { input = input }),
             () => new { createSignatureOrder = new Types.CreateSignatureOrderOutput() }
@@ -62,5 +64,56 @@ public class CriiptoSignaturesClient : IDisposable
         }
 
         return response.Data.createSignatureOrder.signatureOrder;
+    }
+
+    public async Task<Types.Signatory> AddSignatory(Types.AddSignatoryInput input)
+    {
+        var response = await graphQLClient.SendMutationAsync(
+            AddSignatoryMutation.Request(new { input = input }),
+            () => new { addSignatory = new Types.AddSignatoryOutput() }
+        ).ConfigureAwait(false);
+
+        if (response.Errors?.Length > 0)
+        {
+            throw new GraphQLException(response.Errors[0].Message);
+        }
+
+        return response.Data.addSignatory.signatory;
+    }
+
+    public async Task<Types.Signatory> AddSignatory(Types.SignatureOrder signatureOrder)
+    {
+        if (signatureOrder == null) throw new ArgumentNullException(nameof(signatureOrder));
+
+        var input = new Types.AddSignatoryInput();
+        input.signatureOrderId = signatureOrder.id;
+        return await AddSignatory(input).ConfigureAwait(false);
+    }
+
+    public async Task<Types.Signatory> AddSignatory(Types.SignatureOrder signatureOrder, Types.AddSignatoryInput input)
+    {
+        if (signatureOrder == null) throw new ArgumentNullException(nameof(signatureOrder));
+        if (input == null) throw new ArgumentNullException(nameof(input));
+
+        input.signatureOrderId = signatureOrder.id;
+        return await AddSignatory(input).ConfigureAwait(false);
+    }
+
+    public async Task<Types.Signatory> AddSignatory(string signatureOrderId)
+    {
+        if (signatureOrderId == null) throw new ArgumentNullException(nameof(signatureOrderId));
+
+        var input = new Types.AddSignatoryInput();
+        input.signatureOrderId = signatureOrderId;
+        return await AddSignatory(input).ConfigureAwait(false);
+    }
+
+    public async Task<Types.Signatory> AddSignatory(string signatureOrderId, Types.AddSignatoryInput input)
+    {
+        if (signatureOrderId == null) throw new ArgumentNullException(nameof(signatureOrderId));
+        if (input == null) throw new ArgumentNullException(nameof(input));
+
+        input.signatureOrderId = signatureOrderId;
+        return await AddSignatory(input).ConfigureAwait(false);
     }
 }

--- a/Criipto.Signatures/Operations.cs
+++ b/Criipto.Signatures/Operations.cs
@@ -48,6 +48,40 @@ namespace Criipto.Signatures {
     }
     
 
+    public class AddSignatoryMutation {
+      /// <summary>
+      /// AddSignatoryMutation.Request 
+      /// <para>Required variables:<br/> { input=(AddSignatoryInput) }</para>
+      /// <para>Optional variables:<br/> {  }</para>
+      /// </summary>
+      public static GraphQLRequest Request(object variables = null) {
+        return new GraphQLRequest {
+          Query = AddSignatoryDocument,
+          OperationName = "addSignatory",
+          Variables = variables
+        };
+      }
+
+      /// <remarks>This method is obsolete. Use Request instead.</remarks>
+      public static GraphQLRequest getAddSignatoryMutation() {
+        return Request();
+      }
+      
+      public static string AddSignatoryDocument = @"
+        mutation addSignatory($input: AddSignatoryInput!) {
+          addSignatory(input: $input) {
+            signatory {
+              id
+              status
+              href
+            }
+          }
+        }
+        ";
+      
+    }
+    
+
     public class SignatureOrderQuery {
       /// <summary>
       /// SignatureOrderQuery.Request 

--- a/Criipto.Signatures/operations.graphql
+++ b/Criipto.Signatures/operations.graphql
@@ -16,6 +16,16 @@ mutation createSignatureOrder ($input: CreateSignatureOrderInput!) {
   }
 }
 
+mutation addSignatory ($input: AddSignatoryInput!) {
+  addSignatory(input: $input) {
+    signatory {
+      id
+      status
+      href
+    }
+  }
+}
+
 query signatureOrder($id: ID!) {
   signatureOrder(id: $id) {
     status


### PR DESCRIPTION
I considered whether we should return a client aware SignatureOrder type, instead of just returning the converted GraphQL type, but for now i'll be sticking to just top level arguments and the implementer will have to carry the return values/ids around