### PR TITLE
Add support for interacting with batch signatory

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.201'
+          dotnet-version: '8.0.x'
       - name: dummy appsettings.test.json
         shell: bash
         run: echo '{}' > appsettings.test.json

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,6 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.201'
+          dotnet-version: '8.0.x'
       - run: dotnet test
         working-directory: Criipto.Signatures.UnitTests

--- a/Criipto.Signatures.ConsoleExample/Criipto.Signatures.ConsoleExample.csproj
+++ b/Criipto.Signatures.ConsoleExample/Criipto.Signatures.ConsoleExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Criipto.Signatures.IntegrationTests/CreateBatchSignatoryTests.cs
+++ b/Criipto.Signatures.IntegrationTests/CreateBatchSignatoryTests.cs
@@ -1,0 +1,90 @@
+using Xunit;
+using System.Threading.Tasks;
+using Criipto.Signatures.Models;
+
+namespace Criipto.Signatures.IntegrationTests;
+
+public class CreateBatchSignatoryTests
+{
+    private static async Task<(SignatureOrder, Signatory)> CreateSignatoryPair(CriiptoSignaturesClient client)
+    {
+        var signatureOrder = await client.CreateSignatureOrder(
+            new CreateSignatureOrderInput()
+            {
+                title = "Title",
+                expiresInDays = 1,
+                documents =
+                [
+                    new DocumentInput {
+                        pdf =
+                            new PadesDocumentInput
+                            {
+                                title = "TEST",
+                                blob = Dsl.Sample
+                            }
+                    }
+                ]
+            }
+        );
+
+        var signatory = await client.AddSignatory(signatureOrder);
+
+        return (signatureOrder, signatory);
+    }
+
+    [Fact]
+    public async Task MutationReturnsBatchSignatory()
+    {
+        // arrange
+        using var client = new CriiptoSignaturesClient(Dsl.CLIENT_ID, Dsl.CLIENT_SECRET, "test");
+
+        // create the signatory pairs for the batch signatory
+        var (signatureOrderA, signatoryA) = await CreateSignatoryPair(client);
+        var (signatureOrderB, signatoryB) = await CreateSignatoryPair(client);
+
+        var createBatchSignatoryInput = new CreateBatchSignatoryInput
+        {
+            items = [
+                new BatchSignatoryItemInput { signatoryId = signatoryA.id, signatureOrderId = signatureOrderA.id },
+                new BatchSignatoryItemInput { signatoryId = signatoryB.id, signatureOrderId = signatureOrderB.id }
+            ]
+        };
+
+        // act
+        var batchSignatory = await client.CreateBatchSignatory(createBatchSignatoryInput);
+
+        // assert
+        Assert.NotEmpty(batchSignatory.href);
+
+        Assert.Equal(createBatchSignatoryInput.items.Count, batchSignatory.items.Count);
+    }
+
+    [Fact]
+    public async Task QueryReturnsBatchSignatory()
+    {
+        // arrange
+        using var client = new CriiptoSignaturesClient(Dsl.CLIENT_ID, Dsl.CLIENT_SECRET, "test");
+
+        // create the signatory pairs for the batch signatory
+        var (signatureOrderA, signatoryA) = await CreateSignatoryPair(client);
+        var (signatureOrderB, signatoryB) = await CreateSignatoryPair(client);
+
+        var createBatchSignatoryInput = new CreateBatchSignatoryInput
+        {
+            items = [
+                new BatchSignatoryItemInput { signatoryId = signatoryA.id, signatureOrderId = signatureOrderA.id },
+                new BatchSignatoryItemInput { signatoryId = signatoryB.id, signatureOrderId = signatureOrderB.id }
+            ]
+        };
+
+        var createBatchSignatory = await client.CreateBatchSignatory(createBatchSignatoryInput);
+
+        // act
+        var queriedBatchSignatory = await client.QueryBatchSignatory(createBatchSignatory.id);
+
+        // assert
+        Assert.NotNull(queriedBatchSignatory);
+
+        Assert.Equal(createBatchSignatory.token, queriedBatchSignatory.token);
+    }
+}

--- a/Criipto.Signatures.IntegrationTests/Criipto.Signatures.IntegrationTests.csproj
+++ b/Criipto.Signatures.IntegrationTests/Criipto.Signatures.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Criipto.Signatures.UnitTests/Criipto.Signatures.UnitTests.csproj
+++ b/Criipto.Signatures.UnitTests/Criipto.Signatures.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Criipto.Signatures/Client.cs
+++ b/Criipto.Signatures/Client.cs
@@ -171,6 +171,18 @@ public class CriiptoSignaturesClient : IDisposable
         return await AddSignatories(input).ConfigureAwait(false);
     }
 
+    public async Task<BatchSignatory> CreateBatchSignatory(CreateBatchSignatoryInput input)
+    {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+
+        var data = await SendMutation(
+            CreateBatchSignatoryMutation.Request(new { input = input }),
+            () => new { createBatchSignatory = new CreateBatchSignatoryOutput() }
+        ).ConfigureAwait(false);
+
+        return data.createBatchSignatory.batchSignatory;
+    }
+
     public async Task<Signatory> ChangeSignatory(ChangeSignatoryInput input)
     {
         var data = await SendMutation(
@@ -428,5 +440,22 @@ public class CriiptoSignaturesClient : IDisposable
         }
 
         return response.Data.signatory;
+    }
+
+    public async Task<BatchSignatory?> QueryBatchSignatory(string batchSignatoryId)
+    {
+        if (batchSignatoryId == null) throw new ArgumentNullException(nameof(batchSignatoryId));
+
+        var request = BatchSignatoryQuery.Request(new { id = batchSignatoryId });
+
+        var response = await graphQLClient.SendQueryAsync<Query>(request)
+            .ConfigureAwait(false);
+
+        if (response.Errors?.Length > 0)
+        {
+            throw new GraphQLException(response.Errors[0].Message);
+        }
+
+        return response.Data.batchSignatory;
     }
 }

--- a/Criipto.Signatures/Models.cs
+++ b/Criipto.Signatures/Models.cs
@@ -263,6 +263,110 @@ namespace Criipto.Signatures.Models {
     }
     
     
+    #region BatchSignatory
+    public class BatchSignatory {
+      #region members
+      [JsonProperty("href")]
+      public string href { get; set; }
+    
+      [JsonProperty("id")]
+      public string id { get; set; }
+    
+      [JsonProperty("items")]
+      public List<BatchSignatoryItem> items { get; set; }
+    
+      /// <summary>
+      /// The authentication token required for performing batch operations.
+      /// </summary>
+      [JsonProperty("token")]
+      public string token { get; set; }
+    
+      [JsonProperty("ui")]
+      public SignatureOrderUI ui { get; set; }
+      #endregion
+    }
+    #endregion
+    
+    #region BatchSignatoryItem
+    public class BatchSignatoryItem {
+      #region members
+      [JsonProperty("signatory")]
+      public Signatory signatory { get; set; }
+    
+      [JsonProperty("signatureOrder")]
+      public SignatureOrder signatureOrder { get; set; }
+      #endregion
+    }
+    #endregion
+    
+    #region BatchSignatoryItemInput
+    public class BatchSignatoryItemInput {
+      #region members
+      [Required]
+      [JsonRequired]
+      public string signatoryId { get; set; }
+    
+      [Required]
+      [JsonRequired]
+      public string signatureOrderId { get; set; }
+      #endregion
+    
+      #region methods
+      public dynamic GetInputObject()
+      {
+        IDictionary<string, object> d = new System.Dynamic.ExpandoObject();
+    
+        var properties = GetType().GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+        foreach (var propertyInfo in properties)
+        {
+          var value = propertyInfo.GetValue(this);
+          var defaultValue = propertyInfo.PropertyType.IsValueType ? Activator.CreateInstance(propertyInfo.PropertyType) : null;
+    
+          var requiredProp = propertyInfo.GetCustomAttributes(typeof(JsonRequiredAttribute), false).Length > 0;
+    
+          if (requiredProp || value != defaultValue)
+          {
+            d[propertyInfo.Name] = value;
+          }
+        }
+        return d;
+      }
+      #endregion
+    }
+    #endregion
+    
+    #region BatchSignatoryViewer
+    public class BatchSignatoryViewer : Viewer {
+      #region members
+      [JsonProperty("authenticated")]
+      public bool authenticated { get; set; }
+    
+      [JsonProperty("batchSignatoryId")]
+      public string batchSignatoryId { get; set; }
+    
+      [JsonProperty("documents")]
+      public SignatoryDocumentConnection documents { get; set; }
+    
+      [JsonProperty("evidenceProviders")]
+      [JsonConverter(typeof(CompositionTypeListConverter))]
+      public List<SignatureEvidenceProvider> evidenceProviders { get; set; }
+    
+      [JsonProperty("id")]
+      public string id { get; set; }
+    
+      [JsonProperty("signer")]
+      public bool signer { get; set; }
+    
+      [JsonProperty("status")]
+      [JsonConverter(typeof(TolerantEnumConverter))]
+      public SignatoryStatus status { get; set; }
+    
+      [JsonProperty("ui")]
+      public SignatureOrderUI ui { get; set; }
+      #endregion
+    }
+    #endregion
+    
     #region CancelSignatureOrderInput
     public class CancelSignatureOrderInput {
       #region members
@@ -586,6 +690,52 @@ namespace Criipto.Signatures.Models {
     
       [JsonProperty("tenant")]
       public Tenant tenant { get; set; }
+      #endregion
+    }
+    #endregion
+    
+    #region CreateBatchSignatoryInput
+    public class CreateBatchSignatoryInput {
+      #region members
+      [Required]
+      [JsonRequired]
+      public List<BatchSignatoryItemInput> items { get; set; }
+    
+      /// <summary>
+      /// UI settings for batch signatory, will use defaults otherwise (will not use UI settings from sub signatories)
+      /// </summary>
+      public SignatoryUiInput ui { get; set; }
+      #endregion
+    
+      #region methods
+      public dynamic GetInputObject()
+      {
+        IDictionary<string, object> d = new System.Dynamic.ExpandoObject();
+    
+        var properties = GetType().GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+        foreach (var propertyInfo in properties)
+        {
+          var value = propertyInfo.GetValue(this);
+          var defaultValue = propertyInfo.PropertyType.IsValueType ? Activator.CreateInstance(propertyInfo.PropertyType) : null;
+    
+          var requiredProp = propertyInfo.GetCustomAttributes(typeof(JsonRequiredAttribute), false).Length > 0;
+    
+          if (requiredProp || value != defaultValue)
+          {
+            d[propertyInfo.Name] = value;
+          }
+        }
+        return d;
+      }
+      #endregion
+    }
+    #endregion
+    
+    #region CreateBatchSignatoryOutput
+    public class CreateBatchSignatoryOutput {
+      #region members
+      [JsonProperty("batchSignatory")]
+      public BatchSignatory batchSignatory { get; set; }
       #endregion
     }
     #endregion
@@ -1325,7 +1475,7 @@ namespace Criipto.Signatures.Models {
       public NoopEvidenceProviderInput noop { get; set; }
     
       /// <summary>
-      /// OIDC/JWT based evidence for signatures.
+      /// Deprecated
       /// </summary>
       public OidcEvidenceProviderInput oidc { get; set; }
       #endregion
@@ -1484,6 +1634,9 @@ namespace Criipto.Signatures.Models {
       /// </summary>
       [JsonProperty("createApplicationApiKey")]
       public CreateApplicationApiKeyOutput createApplicationApiKey { get; set; }
+    
+      [JsonProperty("createBatchSignatory")]
+      public CreateBatchSignatoryOutput createBatchSignatory { get; set; }
     
       /// <summary>
       /// Creates a signature order to be signed.
@@ -1812,6 +1965,12 @@ namespace Criipto.Signatures.Models {
       [JsonProperty("blob")]
       public byte[] blob { get; set; }
     
+      /// <summary>
+      /// Same value as stamped on document when using displayDocumentID
+      /// </summary>
+      [JsonProperty("documentID")]
+      public string documentID { get; set; }
+    
       [JsonProperty("form")]
       public PdfDocumentForm form { get; set; }
     
@@ -1892,6 +2051,9 @@ namespace Criipto.Signatures.Models {
       #region members
       [JsonProperty("application")]
       public Application application { get; set; }
+    
+      [JsonProperty("batchSignatory")]
+      public BatchSignatory batchSignatory { get; set; }
     
       [JsonProperty("document")]
       [JsonConverter(typeof(CompositionTypeConverter))]
@@ -2601,7 +2763,7 @@ namespace Criipto.Signatures.Models {
       public NoopEvidenceProviderInput noop { get; set; }
     
       /// <summary>
-      /// OIDC/JWT based evidence for signatures.
+      /// Deprecated
       /// </summary>
       public OidcEvidenceProviderInput oidc { get; set; }
       #endregion
@@ -3147,7 +3309,7 @@ namespace Criipto.Signatures.Models {
       public NoopEvidenceProviderInput noop { get; set; }
     
       /// <summary>
-      /// OIDC/JWT based evidence for signatures.
+      /// Deprecated
       /// </summary>
       public OidcEvidenceProviderInput oidc { get; set; }
       #endregion

--- a/Criipto.Signatures/Operations.cs
+++ b/Criipto.Signatures/Operations.cs
@@ -767,6 +767,91 @@ namespace Criipto.Signatures {
     }
     
 
+    public class CreateBatchSignatoryMutation {
+      /// <summary>
+      /// CreateBatchSignatoryMutation.Request 
+      /// <para>Required variables:<br/> { input=(CreateBatchSignatoryInput) }</para>
+      /// <para>Optional variables:<br/> {  }</para>
+      /// </summary>
+      public static GraphQLRequest Request(object variables = null) {
+        return new GraphQLRequest {
+          Query = CreateBatchSignatoryDocument,
+          OperationName = "createBatchSignatory",
+          Variables = variables
+        };
+      }
+
+      /// <remarks>This method is obsolete. Use Request instead.</remarks>
+      public static GraphQLRequest getCreateBatchSignatoryMutation() {
+        return Request();
+      }
+      
+      public static string CreateBatchSignatoryDocument = @"
+        mutation createBatchSignatory($input: CreateBatchSignatoryInput!) {
+          createBatchSignatory(input: $input) {
+            batchSignatory {
+              ...BasicBatchSignatory
+              items {
+                signatureOrder {
+                  ...BasicSignatureOrder
+                }
+                signatory {
+                  ...BasicSignatory
+                }
+              }
+            }
+          }
+        }
+        fragment BasicSignatory on Signatory {
+          id
+          status
+          statusReason
+          href
+          downloadHref
+          reference
+          role
+          signatureOrder {
+            id
+            status
+            closedAt
+            expiresAt
+          }
+          evidenceProviders {
+            __typename
+            id
+          }
+          documents {
+            edges {
+              status
+              node {
+                __typename
+                id
+              }
+            }
+          }
+        }
+        fragment BasicSignatureOrder on SignatureOrder {
+          id
+          status
+          closedAt
+          expiresAt
+          signatories {
+            ...BasicSignatory
+          }
+          evidenceProviders {
+            __typename
+            id
+          }
+        }
+        fragment BasicBatchSignatory on BatchSignatory {
+          id
+          token
+          href
+        }";
+      
+    }
+    
+
     public class SignatureOrderQuery {
       /// <summary>
       /// SignatureOrderQuery.Request 
@@ -998,6 +1083,89 @@ namespace Criipto.Signatures {
             __typename
             id
           }
+        }";
+      
+    }
+    
+
+    public class BatchSignatoryQuery {
+      /// <summary>
+      /// BatchSignatoryQuery.Request 
+      /// <para>Required variables:<br/> { id=(string) }</para>
+      /// <para>Optional variables:<br/> {  }</para>
+      /// </summary>
+      public static GraphQLRequest Request(object variables = null) {
+        return new GraphQLRequest {
+          Query = BatchSignatoryDocument,
+          OperationName = "batchSignatory",
+          Variables = variables
+        };
+      }
+
+      /// <remarks>This method is obsolete. Use Request instead.</remarks>
+      public static GraphQLRequest getBatchSignatoryQuery() {
+        return Request();
+      }
+      
+      public static string BatchSignatoryDocument = @"
+        query batchSignatory($id: ID!) {
+          batchSignatory(id: $id) {
+            ...BasicBatchSignatory
+            items {
+              signatureOrder {
+                ...BasicSignatureOrder
+              }
+              signatory {
+                ...BasicSignatory
+              }
+            }
+          }
+        }
+        fragment BasicSignatory on Signatory {
+          id
+          status
+          statusReason
+          href
+          downloadHref
+          reference
+          role
+          signatureOrder {
+            id
+            status
+            closedAt
+            expiresAt
+          }
+          evidenceProviders {
+            __typename
+            id
+          }
+          documents {
+            edges {
+              status
+              node {
+                __typename
+                id
+              }
+            }
+          }
+        }
+        fragment BasicSignatureOrder on SignatureOrder {
+          id
+          status
+          closedAt
+          expiresAt
+          signatories {
+            ...BasicSignatory
+          }
+          evidenceProviders {
+            __typename
+            id
+          }
+        }
+        fragment BasicBatchSignatory on BatchSignatory {
+          id
+          token
+          href
         }";
       
     }

--- a/Criipto.Signatures/operations.graphql
+++ b/Criipto.Signatures/operations.graphql
@@ -65,6 +65,12 @@ fragment BasicSignatureOrder on SignatureOrder {
   }
 }
 
+fragment BasicBatchSignatory on BatchSignatory {
+  id
+  token
+  href
+}
+
 mutation createSignatureOrder($input: CreateSignatureOrderInput!) {
   createSignatureOrder(input: $input) {
     signatureOrder {
@@ -169,6 +175,24 @@ mutation deleteSignatory($input: DeleteSignatoryInput!) {
   }
 }
 
+mutation createBatchSignatory($input: CreateBatchSignatoryInput!) {
+  createBatchSignatory(input: $input) {
+    batchSignatory {
+      ...BasicBatchSignatory
+
+      items {
+        signatureOrder {
+          ...BasicSignatureOrder
+        }
+
+        signatory {
+          ...BasicSignatory
+        }
+      }
+    }
+  }
+}
+
 query signatureOrder($id: ID!) {
   signatureOrder(id: $id) {
     ... BasicSignatureOrder
@@ -191,6 +215,22 @@ query signatory($id: ID!) {
     ...BasicSignatory
     signatureOrder {
       ...BasicSignatureOrder
+    }
+  }
+}
+
+query batchSignatory($id: ID!) {
+  batchSignatory(id: $id) {
+    ...BasicBatchSignatory
+
+    items {
+      signatureOrder {
+        ...BasicSignatureOrder
+      }
+
+      signatory {
+        ...BasicSignatory
+      }
     }
   }
 }


### PR DESCRIPTION
Batch signatory is a new feature that allows combining multiple signatories across one or more signature orders, and then perform a single batch operation, i.e., signing or rejecting.

Additionally, OIDC evidence provider has been marked as deprecated.